### PR TITLE
Raising error for heartbeat poll expired

### DIFF
--- a/kafka/coordinator/base.py
+++ b/kafka/coordinator/base.py
@@ -990,6 +990,7 @@ class HeartbeatThread(threading.Thread):
                 # foreground thread has stalled in between calls to
                 # poll(), so we explicitly leave the group.
                 log.warning('Heartbeat poll expired, leaving group')
+                log.error('Heartbeat timed out after 5 minutes')
                 exit() # This is 5 minute timeout
                 # self.coordinator.maybe_leave_group()
 

--- a/kafka/coordinator/base.py
+++ b/kafka/coordinator/base.py
@@ -991,10 +991,9 @@ class HeartbeatThread(threading.Thread):
                 # foreground thread has stalled in between calls to
                 # poll(), so we explicitly leave the group.
                 log.warning('Heartbeat poll expired, leaving group')
-                log.error('Heartbeat timed out after 5 minutes')
-                raise Errors.KafkaError('Heartbeat poll expired')
-                sys.exit() # This is 5 minute timeout
                 # self.coordinator.maybe_leave_group()
+                # exit if heartbeat poll expires (should not take 5 minutes)
+                raise Errors.KafkaError('Heartbeat poll expired')
 
             elif not self.coordinator.heartbeat.should_heartbeat():
                 # poll again after waiting for the retry backoff in case

--- a/kafka/coordinator/base.py
+++ b/kafka/coordinator/base.py
@@ -990,7 +990,8 @@ class HeartbeatThread(threading.Thread):
                 # foreground thread has stalled in between calls to
                 # poll(), so we explicitly leave the group.
                 log.warning('Heartbeat poll expired, leaving group')
-                self.coordinator.maybe_leave_group()
+                exit() # This is 5 minute timeout
+                # self.coordinator.maybe_leave_group()
 
             elif not self.coordinator.heartbeat.should_heartbeat():
                 # poll again after waiting for the retry backoff in case

--- a/kafka/coordinator/base.py
+++ b/kafka/coordinator/base.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division
 import abc
 import copy
 import logging
+import sys
 import threading
 import time
 import weakref
@@ -991,7 +992,7 @@ class HeartbeatThread(threading.Thread):
                 # poll(), so we explicitly leave the group.
                 log.warning('Heartbeat poll expired, leaving group')
                 log.error('Heartbeat timed out after 5 minutes')
-                exit() # This is 5 minute timeout
+                sys.exit() # This is 5 minute timeout
                 # self.coordinator.maybe_leave_group()
 
             elif not self.coordinator.heartbeat.should_heartbeat():

--- a/kafka/coordinator/base.py
+++ b/kafka/coordinator/base.py
@@ -992,6 +992,7 @@ class HeartbeatThread(threading.Thread):
                 # poll(), so we explicitly leave the group.
                 log.warning('Heartbeat poll expired, leaving group')
                 log.error('Heartbeat timed out after 5 minutes')
+                raise Errors.KafkaError('Heartbeat poll expired')
                 sys.exit() # This is 5 minute timeout
                 # self.coordinator.maybe_leave_group()
 


### PR DESCRIPTION
Forces task to error when heartbeat poll expires (5 minutes)
This works around the 'zombie state' and can subsequently spin up a new ECS task